### PR TITLE
Added basic handling for multipie links

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -1148,45 +1148,6 @@ export class App {
       .option("-p, --project [project]", "Specify the project the report should be printed for")
       .action((cmd: Command): Promise<void> => this.reportAction(cmd));
 
-    // log command
-    // not needed anymore
-    // commander
-    //   .command("log")
-    //   .description("List of local changes")
-    //   .action(async () => {
-    //     const logs: ReadonlyArray<DefaultLogFields> = await this.gitHelper.logChanges();
-    //     if (logs.length > 0) {
-    //       LogHelper.warn("Local changes:");
-    //       for (const log of logs) {
-    //         console.log(`${log.date}\n  ${log.message.trim()}`);
-    //       }
-    //     } else {
-    //       LogHelper.info("Everything is up to date");
-    //     }
-    //   });
-
-    // status command
-    // not needed anymore
-    // commander
-    //   .command("status")
-    //   .description("Overview of all projects")
-    //   .action(async () => {
-    //     const projects: IProject[] = await this.fileHelper.findAllProjects();
-    //     let totalHours: number = 0;
-
-    //     LogHelper.info("Projects:");
-    //     for (const pL of projects) {
-    //       const hours: number = await this.projectHelper.getTotalHours(pL.name);
-    //       LogHelper.info(`${pL.name}:\t${hours}`);
-    //       totalHours += hours;
-    //     }
-    //     LogHelper.info("");
-
-    //     LogHelper.info("Summery:");
-    //     LogHelper.info(`Total projects:\t${projects.length}`);
-    //     LogHelper.info(`Total hours:\t${totalHours}`);
-    //   });
-
     commander
       .command("setup")
       .description("Initializes config directory and setup of gittt git project")

--- a/app.ts
+++ b/app.ts
@@ -173,7 +173,7 @@ export class App {
 
         LogHelper.debug(`Trying to find links for "${project.name}"`)
         // Check for previous data
-        const prevJiraIntegrationLink: IIntegrationLink | undefined = await this.fileHelper.findLinkByProject(project, "Jira");
+        const prevJiraIntegrationLink: IIntegrationLink | undefined = await this.fileHelper.findLinkByProject(project);
         let prevJiraLink: IJiraLink | undefined;
         if (prevJiraIntegrationLink) {
           LogHelper.info(`Found link for "${project.name}", enriching dialog with previous data`)
@@ -183,7 +183,7 @@ export class App {
         const jiraLink: IJiraLink = await QuestionHelper.askJiraLink(project, prevJiraLink, JIRA_ENDPOINT_VERSION);
 
         try {
-          await this.fileHelper.addOrUpdateLink(jiraLink, "Jira");
+          await this.fileHelper.addOrUpdateLink(jiraLink);
         } catch (err) {
           LogHelper.debug(`Unable to add link to config file`, err);
           return this.exit(`Unable to add link to config file`, 1);
@@ -194,7 +194,7 @@ export class App {
       case "Multipie":
         LogHelper.debug(`Trying to find links for "${project.name}"`)
         // Check for previous data
-        const prevMultipieIntegrationLink: IIntegrationLink | undefined = await this.fileHelper.findLinkByProject(project, "Multipie");
+        const prevMultipieIntegrationLink: IIntegrationLink | undefined = await this.fileHelper.findLinkByProject(project);
         let prevMultipieLink: IMultipieLink | undefined;
         if (prevMultipieIntegrationLink) {
           LogHelper.info(`Found link for "${project.name}", enriching dialog with previous data`)
@@ -204,7 +204,7 @@ export class App {
         const multiPieLink: IMultipieLink = await QuestionHelper.askMultipieLink(project, prevMultipieLink);
 
         try {
-          await this.fileHelper.addOrUpdateLink(multiPieLink, "Multipie");
+          await this.fileHelper.addOrUpdateLink(multiPieLink);
         } catch (err) {
           LogHelper.debug(`Unable to add link to config file`, err);
           return this.exit(`Unable to add link to config file`, 1);
@@ -858,7 +858,7 @@ export class App {
         LogHelper.log(`Hours:\t${hours}h`);
 
         // TODO make this multi link capable
-        const link: IIntegrationLink | undefined = await this.fileHelper.findLinkByProject(project, "Jira");
+        const link: IIntegrationLink | undefined = await this.fileHelper.findLinkByProject(project);
         if (link) {
           switch (link.linkType) {
             case "Jira":

--- a/helper/file.ts
+++ b/helper/file.ts
@@ -1,7 +1,7 @@
 import plainFs from "fs";
 import fs, { WriteOptions } from "fs-extra";
 import path from "path";
-import { IConfigFile, IIntegrationLink, IJiraLink, IProject, IProjectMeta, ITimerFile } from "../interfaces";
+import { IConfigFile, IIntegrationLink, IJiraLink, IMultipieLink, IProject, IProjectMeta, ITimerFile } from "../interfaces";
 import { LogHelper, parseProjectNameFromGitUrl, ProjectHelper } from "./";
 
 export class FileHelper {
@@ -68,13 +68,14 @@ export class FileHelper {
     return initial;
   }
 
-  public addOrUpdateLink = async (link: IIntegrationLink | IJiraLink): Promise<IConfigFile> => {
+  public addOrUpdateLink = async (link: IIntegrationLink | IJiraLink | IMultipieLink, linkType: string): Promise<IConfigFile> => {
     const configObject: IConfigFile = await this.getConfigObject();
 
     // TODO check if already exists
     const cleanLinks: IIntegrationLink[] = configObject.links.filter((li: IIntegrationLink) => {
+      // TODO linkType can be taken from class
       // TODO TBD: use different parameters as unique? e.g. more than one jira link per project?
-      return li.projectName !== link.projectName;
+      return li.projectName !== link.projectName && li.linkType !== linkType;
     });
 
     cleanLinks.push(link);
@@ -86,12 +87,12 @@ export class FileHelper {
     return configObject;
   }
 
-  public findLinkByProject = async (project: IProject): Promise<IIntegrationLink | undefined> => {
+  public findLinkByProject = async (project: IProject, linkType: string): Promise<IIntegrationLink | undefined> => {
     const configObject: IConfigFile = await this.getConfigObject();
 
     const foundLinks: IIntegrationLink[] = configObject.links.filter((li: IIntegrationLink) => {
       // TODO TBD: use different parameters as unique? e.g. more than one jira link per project?
-      return li.projectName === project.name;
+      return li.projectName === project.name && li.linkType == linkType;
     });
 
     if (foundLinks.length === 0) {

--- a/helper/file.ts
+++ b/helper/file.ts
@@ -68,14 +68,14 @@ export class FileHelper {
     return initial;
   }
 
-  public addOrUpdateLink = async (link: IIntegrationLink | IJiraLink | IMultipieLink, linkType: string): Promise<IConfigFile> => {
+  public addOrUpdateLink = async (link: IIntegrationLink | IJiraLink | IMultipieLink): Promise<IConfigFile> => {
     const configObject: IConfigFile = await this.getConfigObject();
 
     // TODO check if already exists
     const cleanLinks: IIntegrationLink[] = configObject.links.filter((li: IIntegrationLink) => {
       // TODO linkType can be taken from class
       // TODO TBD: use different parameters as unique? e.g. more than one jira link per project?
-      return li.projectName !== link.projectName && li.linkType !== linkType;
+      return li.projectName !== link.projectName && li.linkType !== link.linkType;
     });
 
     cleanLinks.push(link);
@@ -87,12 +87,12 @@ export class FileHelper {
     return configObject;
   }
 
-  public findLinkByProject = async (project: IProject, linkType: string): Promise<IIntegrationLink | undefined> => {
+  public findLinkByProject = async (project: IProject): Promise<IIntegrationLink | undefined> => {
     const configObject: IConfigFile = await this.getConfigObject();
 
     const foundLinks: IIntegrationLink[] = configObject.links.filter((li: IIntegrationLink) => {
       // TODO TBD: use different parameters as unique? e.g. more than one jira link per project?
-      return li.projectName === project.name && li.linkType == linkType;
+      return li.projectName === project.name;
     });
 
     if (foundLinks.length === 0) {

--- a/helper/project.ts
+++ b/helper/project.ts
@@ -320,7 +320,7 @@ export class ProjectHelper {
     }
 
     // TODO handle multiple links
-    const link: IIntegrationLink | undefined = await this.fileHelper.findLinkByProject(from, "Jira");
+    const link: IIntegrationLink | undefined = await this.fileHelper.findLinkByProject(from);
     if (!link) {
       LogHelper.debug(`No link found for project "${from.name}"`);
     } else {
@@ -329,7 +329,7 @@ export class ProjectHelper {
           const migratedLink: IJiraLink = link as IJiraLink;
           migratedLink.projectName = to.name;
 
-          await this.fileHelper.addOrUpdateLink(migratedLink, "Jira");
+          await this.fileHelper.addOrUpdateLink(migratedLink);
           LogHelper.info(`✓ Updated jira link`);
           break;
 

--- a/helper/project.ts
+++ b/helper/project.ts
@@ -319,7 +319,8 @@ export class ProjectHelper {
       LogHelper.info(`✓ Removed old domain directory`);
     }
 
-    const link: IIntegrationLink | undefined = await this.fileHelper.findLinkByProject(from);
+    // TODO handle multiple links
+    const link: IIntegrationLink | undefined = await this.fileHelper.findLinkByProject(from, "Jira");
     if (!link) {
       LogHelper.debug(`No link found for project "${from.name}"`);
     } else {
@@ -328,7 +329,7 @@ export class ProjectHelper {
           const migratedLink: IJiraLink = link as IJiraLink;
           migratedLink.projectName = to.name;
 
-          await this.fileHelper.addOrUpdateLink(migratedLink);
+          await this.fileHelper.addOrUpdateLink(migratedLink, "Jira");
           LogHelper.info(`✓ Updated jira link`);
           break;
 

--- a/helper/question.ts
+++ b/helper/question.ts
@@ -1,7 +1,7 @@
 import inquirer, { ListQuestion, Question } from "inquirer";
 import _ from "lodash";
 import moment from "moment";
-import { IJiraLink, IProject, IRecord } from "../interfaces";
+import { IJiraLink, IMultipieLink, IProject, IRecord } from "../interfaces";
 import { RECORD_TYPES } from "../types";
 import { ProjectHelper, ValidationHelper } from "./";
 
@@ -192,6 +192,40 @@ export class QuestionHelper {
     return link;
   }
 
+  public static askMultipieLink = async (project: IProject, prevData?: IMultipieLink): Promise<IMultipieLink> => {
+    const multipieAnswers: any = await inquirer.prompt([
+      {
+        default: prevData ? prevData.host : "https://multipie.gittt.org",
+        // also works for generic hosts
+        filter: QuestionHelper.filterJiraEndpoint,
+        message: "Multipie host",
+        name: "host",
+        type: "input",
+        validate: ValidationHelper.validateJiraEndpoint,
+      },
+      {
+        default: prevData ? prevData.username : undefined,
+        message: "Multipie username",
+        name: "username",
+        type: "input",
+        // TODO validate
+      },
+    ]);
+    const { host, username } = multipieAnswers;
+
+    const projectName: string = project.name;
+
+    const link: IMultipieLink = {
+      host,
+      endpoint: `/v1/publish`,
+      linkType: "Multipie",
+      projectName,
+      username,
+    };
+
+    return link;
+  }
+
   public static chooseRecord = async (records: IRecord[]): Promise<IRecord> => {
     const choice: any = await inquirer.prompt([
       {
@@ -244,6 +278,7 @@ export class QuestionHelper {
   public static chooseIntegration = async (): Promise<string> => {
     const choices: string[] = [
       "Jira",
+      "Multipie",
     ];
 
     const question: ListQuestion = {

--- a/interfaces/index.ts
+++ b/interfaces/index.ts
@@ -33,6 +33,12 @@ export interface IJiraLink extends IIntegrationLink {
   issue: string;
 }
 
+export interface IMultipieLink extends IIntegrationLink {
+  username: string;
+  host: string;
+  endpoint: string;
+}
+
 export interface IConfigFile {
   created: number;
   gitRepo: string;

--- a/interfaces/integrations.ts
+++ b/interfaces/integrations.ts
@@ -3,3 +3,9 @@ export interface IJiraPublishResult {
   data?: object;
   message?: string;
 }
+
+export interface IMultipiePublishResult {
+  success: boolean;
+  data?: object;
+  message?: string;
+}

--- a/test/unit/app.test.ts
+++ b/test/unit/app.test.ts
@@ -6,7 +6,7 @@ import { DefaultLogFields } from "simple-git/typings/response";
 import sinon from "sinon";
 import { App } from "../../app";
 import { LogHelper } from "../../helper/index";
-import { IConfigFile, IInitAnswers, IJiraLink, IJiraPublishResult, IProject, IRecord } from "../../interfaces";
+import { IConfigFile, IInitAnswers, IJiraLink, IJiraPublishResult, IProject, IRecord, IMultipieLink, IMultipiePublishResult } from "../../interfaces";
 import { RECORD_TYPES } from "../../types";
 import { emptyHelper } from "../helper";
 
@@ -2243,6 +2243,98 @@ describe("App", function () {
   });
 
   describe("Links", function () {
+    describe("General", function () {
+      it("should fail to add new link [no git directory]", async function () {
+        const mockedHelper: any = Object.assign({}, emptyHelper);
+        const mockedCommander: CommanderStatic = proxyquire("commander", {});
+
+        const getOrAskForProjectFromGitStub = sinon.stub().returns(undefined);
+
+        mockedHelper.FileHelper = class {
+          public static getHomeDir = sinon.stub().returns("/home/test");
+          public configDirExists = sinon.stub().resolves(true);
+          public isConfigFileValid = sinon.stub().resolves(true);
+        }
+
+        mockedHelper.ProjectHelper = class {
+          public getOrAskForProjectFromGit = getOrAskForProjectFromGitStub;
+        }
+
+        const proxy: any = proxyquire("../../app", {
+          "./helper": mockedHelper,
+          "commander": mockedCommander,
+        });
+
+        const mockedApp: App = new proxy.App();
+
+        const exitStub = sinon.stub(mockedApp, "exit");
+
+        await mockedApp.setup();
+
+        const mockedCommand: Command = new Command();
+
+        // Mock arguments array to enable interactive mode
+        process.argv = ["1", "2", "3"];
+
+        await mockedApp.linkAction(mockedCommand);
+
+        assert.isTrue(exitStub.calledOnce);
+
+        exitStub.restore();
+      });
+
+      it("should fail to add new link [unknown integration type]", async function () {
+        const mockedHelper: any = Object.assign({}, emptyHelper);
+
+        const getOrAskForProjectFromGitStub = sinon.stub().returns({
+          meta: {
+            host: "test.git.com",
+            port: 443,
+          },
+          name: "mocked",
+        } as IProject);
+
+        mockedHelper.FileHelper = class {
+          public static getHomeDir = sinon.stub().returns("/home/test");
+          public configDirExists = sinon.stub().resolves(true);
+          public isConfigFileValid = sinon.stub().resolves(true);
+        }
+
+        mockedHelper.ProjectHelper = class {
+          public addLink = sinon.stub().resolves();
+        }
+
+        mockedHelper.ProjectHelper = class {
+          public getOrAskForProjectFromGit = getOrAskForProjectFromGitStub;
+        }
+
+        mockedHelper.QuestionHelper = class {
+          public static chooseIntegration = sinon.stub().resolves("UnknownIntegration");
+        }
+
+        const proxy: any = proxyquire("../../app", {
+          "./helper": mockedHelper,
+        });
+
+        const mockedApp: App = new proxy.App();
+
+        const exitStub = sinon.stub(mockedApp, "exit");
+
+        await mockedApp.setup();
+
+        const mockedCommand: Command = new Command();
+
+        // Mock arguments array to enable interactive mode
+        process.argv = ["1", "2", "3"];
+
+        await mockedApp.linkAction(mockedCommand);
+
+        assert.isTrue(getOrAskForProjectFromGitStub.calledOnce);
+        assert.isTrue(exitStub.calledOnce);
+
+        exitStub.restore();
+      });
+    })
     describe("Jira", function () {
       describe("Add/Edit", function () {
         it("should add new JIRA link", async function () {
@@ -2454,63 +2546,6 @@ describe("App", function () {
           await mockedApp.linkAction(mockedCommand);
 
           assert.isTrue(addOrUpdateLinkStub.calledOnce);
-        });
-
-        it("should fail to add new JIRA link [no git directory]", async function () {
-          const mockedHelper: any = Object.assign({}, emptyHelper);
-          const mockedCommander: CommanderStatic = proxyquire("commander", {});
-
-          const getOrAskForProjectFromGitStub = sinon.stub().returns(undefined);
-          const addOrUpdateLinkStub = sinon.stub().resolves();
-
-          mockedHelper.FileHelper = class {
-            public static getHomeDir = sinon.stub().returns("/home/test");
-            public configDirExists = sinon.stub().resolves(true);
-            public isConfigFileValid = sinon.stub().resolves(true);
-            public addOrUpdateLink = addOrUpdateLinkStub;
-          }
-
-          mockedHelper.ProjectHelper = class {
-            public addLink = sinon.stub().resolves();
-            public getOrAskForProjectFromGit = getOrAskForProjectFromGitStub;
-          }
-
-          mockedHelper.QuestionHelper = class {
-            public static askJiraLink = sinon.stub().resolves(
-              {
-                endpoint: "http://mocked.com/rest/gittt/latest/",
-                hash: "shaHash",
-                key: "MOCKED",
-                linkType: "Jira",
-                projectName: "mocked_,project_1",
-                username: "mocked",
-              } as IJiraLink
-            );
-            public static chooseIntegration = sinon.stub().resolves("Jira");
-          }
-
-          const proxy: any = proxyquire("../../app", {
-            "./helper": mockedHelper,
-            "commander": mockedCommander,
-          });
-
-          const mockedApp: App = new proxy.App();
-
-          const exitStub = sinon.stub(mockedApp, "exit");
-
-          await mockedApp.setup();
-
-          const mockedCommand: Command = new Command();
-
-          // Mock arguments array to enable interactive mode
-          process.argv = ["1", "2", "3"];
-
-          await mockedApp.linkAction(mockedCommand);
-
-          assert.isTrue(exitStub.calledOnce);
-
-          exitStub.restore();
-
         });
 
         it("should fail to add new JIRA link [error while adding]", async function () {
@@ -3741,6 +3776,586 @@ describe("App", function () {
 
           exitStub.restore();
         });
+      });
+    });
+
+    describe("Multipie", function () {
+      describe("Add/Edit", function () {
+        it("should add new Multipie link", async function () {
+          const mockedHelper: any = Object.assign({}, emptyHelper);
+          const addOrUpdateLinkStub = sinon.stub().resolves();
+
+          const getOrAskForProjectFromGitStub = sinon.stub().returns({
+            meta: {
+              host: "test.git.com",
+              port: 443,
+            },
+            name: "mocked",
+          } as IProject);
+          const addRecordsToProjectStub = sinon.stub().resolves();
+
+          mockedHelper.FileHelper = class {
+            public static getHomeDir = sinon.stub().returns("/home/test");
+            public configDirExists = sinon.stub().resolves(true);
+            public isConfigFileValid = sinon.stub().resolves(true);
+            public addOrUpdateLink = addOrUpdateLinkStub;
+            public findLinkByProject = sinon.stub().resolves();
+          }
+
+          mockedHelper.ProjectHelper = class {
+            public addLink = sinon.stub().resolves();
+          }
+
+          mockedHelper.ProjectHelper = class {
+            public addRecordsToProject = addRecordsToProjectStub;
+            public getOrAskForProjectFromGit = getOrAskForProjectFromGitStub;
+          }
+
+          mockedHelper.ValidationHelper = class {
+            public static validateFile = sinon.stub().returns(true);
+          }
+
+          mockedHelper.QuestionHelper = class {
+            public static askMultipieLink = sinon.stub().resolves(
+              {
+                host: "http://mocked.com",
+                endpoint: "/v1/publish",
+                linkType: "Multipie",
+                projectName: "mocked_project_1",
+                username: "mocked",
+              } as IJiraLink
+            );
+            public static chooseIntegration = sinon.stub().resolves("Multipie");
+          }
+
+          const proxy: any = proxyquire("../../app", {
+            "./helper": mockedHelper,
+          });
+
+          const mockedApp: App = new proxy.App();
+
+          await mockedApp.setup();
+
+          const mockedCommand: Command = new Command();
+
+          // Mock arguments array to enable interactive mode
+          process.argv = ["1", "2", "3"];
+
+          await mockedApp.linkAction(mockedCommand);
+
+          assert.isTrue(addOrUpdateLinkStub.calledOnce);
+        });
+
+        it("should add new Multipie link [non interactive]", async function () {
+          const mockedHelper: any = Object.assign({}, emptyHelper);
+
+          const addOrUpdateLinkStub = sinon.stub().resolves();
+
+          const getProjectByNameStub = sinon.stub().returns({
+            meta: {
+              host: "test.git.com",
+              port: 443,
+            },
+            name: "mocked_project_1",
+          } as IProject);
+          const addRecordsToProjectStub = sinon.stub().resolves();
+
+          mockedHelper.FileHelper = class {
+            public static getHomeDir = sinon.stub().returns("/home/test");
+            public configDirExists = sinon.stub().resolves(true);
+            public isConfigFileValid = sinon.stub().resolves(true);
+            public addOrUpdateLink = addOrUpdateLinkStub;
+            public findLinkByProject = sinon.stub().resolves();
+          }
+
+          mockedHelper.ProjectHelper = class {
+            public addLink = sinon.stub().resolves();
+            // public getProjectFromGit = getProjectFromGitStub;
+          }
+
+          mockedHelper.ProjectHelper = class {
+            public addRecordsToProject = addRecordsToProjectStub;
+            public getProjectByName = getProjectByNameStub;
+          }
+
+          mockedHelper.ValidationHelper = class {
+            public static validateFile = sinon.stub().returns(true);
+          }
+
+          mockedHelper.QuestionHelper = class {
+            public static askMultipieLink = sinon.stub().resolves(
+              {
+                host: "http://mocked.com",
+                endpoint: "/v1/publish",
+                linkType: "Multipie",
+                projectName: "mocked_project_1",
+                username: "mocked",
+              } as IMultipieLink
+            );
+            public static chooseIntegration = sinon.stub().resolves("Multipie");
+          }
+
+          const proxy: any = proxyquire("../../app", {
+            "./helper": mockedHelper,
+          });
+
+          const mockedApp: App = new proxy.App();
+
+          await mockedApp.setup();
+
+          const mockedCommand: Command = new Command();
+          mockedCommand.project = "mocked_project_1";
+
+          // Mock arguments array to disable interactive mode
+          process.argv = ["1", "2", "3", "4"];
+
+          await mockedApp.linkAction(mockedCommand);
+
+          assert.isTrue(addOrUpdateLinkStub.calledOnce);
+        });
+
+        it("should edit previous Multipie link", async function () {
+          const mockedHelper: any = Object.assign({}, emptyHelper);
+          const mockedCommander: CommanderStatic = proxyquire("commander", {});
+
+          const getOrAskForProjectFromGitStub = sinon.stub().returns({
+            meta: {
+              host: "github.com",
+              port: 443,
+            },
+            name: "mocked_project_1",
+          } as IProject);
+          const addOrUpdateLinkStub = sinon.stub().resolves();
+
+
+          mockedHelper.FileHelper = class {
+            public static getHomeDir = sinon.stub().returns("/home/test");
+            public configDirExists = sinon.stub().resolves(true);
+            public isConfigFileValid = sinon.stub().resolves(true);
+            public addOrUpdateLink = addOrUpdateLinkStub;
+            public findLinkByProject = sinon.stub().resolves(
+              {
+                endpoint: "/v1/publish",
+                host: "http://github.com",
+                linkType: "Multipie",
+                projectName: "mocked_project_1",
+                username: "mocked"
+              } as IMultipieLink
+            );
+          }
+
+          mockedHelper.ProjectHelper = class {
+            public getOrAskForProjectFromGit = getOrAskForProjectFromGitStub;
+          }
+
+          mockedHelper.QuestionHelper = class {
+            public static askMultipieLink = sinon.stub().resolves(
+              {
+                host: "http://mocked.com",
+                endpoint: "/v1/publish",
+                linkType: "Multipie",
+                projectName: "mocked_,project_1",
+                username: "mocked",
+              } as IMultipieLink
+            );
+            public static chooseIntegration = sinon.stub().resolves("Multipie");
+          }
+
+          const proxy: any = proxyquire("../../app", {
+            "./helper": mockedHelper,
+            "commander": mockedCommander,
+          });
+
+          const mockedApp: App = new proxy.App();
+
+          await mockedApp.setup();
+
+          const mockedCommand: Command = new Command();
+
+          // Mock arguments array to enable interactive mode
+          process.argv = ["1", "2", "3"];
+
+          await mockedApp.linkAction(mockedCommand);
+
+          assert.isTrue(addOrUpdateLinkStub.calledOnce);
+        });
+
+        it("should fail to add new Multipie link [error while adding]", async function () {
+          const mockedHelper: any = Object.assign({}, emptyHelper);
+          const mockedCommander: CommanderStatic = proxyquire("commander", {});
+
+          const getOrAskForProjectFromGitStub = sinon.stub().returns({
+            meta: {
+              host: "github.com",
+              port: 443,
+            },
+            name: "mocked_project_1",
+          } as IProject);
+          const addOrUpdateLinkStub = sinon.stub().throws(new Error("Mocked Error"));
+
+          mockedHelper.FileHelper = class {
+            public static getHomeDir = sinon.stub().returns("/home/test");
+            public configDirExists = sinon.stub().resolves(true);
+            public isConfigFileValid = sinon.stub().resolves(true);
+            public addOrUpdateLink = addOrUpdateLinkStub;
+            public findLinkByProject = sinon.stub().resolves();
+          }
+
+          mockedHelper.ProjectHelper = class {
+            public getOrAskForProjectFromGit = getOrAskForProjectFromGitStub;
+          }
+
+          mockedHelper.QuestionHelper = class {
+            public static askMultipieLink = sinon.stub().resolves(
+              {
+                host: "http://mocked.com",
+                endpoint: "/v1/publish",
+                linkType: "Multipie",
+                projectName: "mocked_,project_1",
+                username: "mocked",
+              } as IMultipieLink
+            );
+            public static chooseIntegration = sinon.stub().resolves("Multipie");
+          }
+
+          const proxy: any = proxyquire("../../app", {
+            "./helper": mockedHelper,
+            "commander": mockedCommander,
+          });
+
+          const mockedApp: App = new proxy.App();
+
+          const exitStub = sinon.stub(mockedApp, "exit");
+
+          await mockedApp.setup();
+
+          const mockedCommand: Command = new Command();
+
+          // Mock arguments array to enable interactive mode
+          process.argv = ["1", "2", "3"];
+
+          await mockedApp.linkAction(mockedCommand);
+
+          assert.isTrue(addOrUpdateLinkStub.calledOnce);
+          assert.isTrue(exitStub.calledOnce);
+
+          exitStub.restore();
+        });
+      });
+
+      describe("Publish", function () {
+        it("should publish records to Multipie endpoint", async function () {
+          const mockedHelper: any = Object.assign({}, emptyHelper);
+
+          const getOrAskForProjectFromGitStub = sinon.stub().returns({
+            meta: {
+              host: "github.com",
+              port: 443,
+            },
+            name: "mocked_project_1",
+          } as IProject);
+          const getConfigObjectStub = sinon.stub().returns({
+            created: 1234,
+            gitRepo: "ssh://git@mocked.com:1337/mocked/test.git",
+            links: [
+              {
+                host: "http://multipie.mocked.com:2990",
+                endpoint: "/v1/publish",
+                linkType: "Multipie",
+                projectName: "mocked_project_1",
+                username: "test",
+              } as IMultipieLink,
+            ],
+          } as IConfigFile);
+          const findProjectByNameStub = sinon.stub().resolves({
+            meta: {
+              host: "github.com",
+              port: 443,
+            },
+            name: "mocked_project_1",
+            records: [],
+          });
+          const logChangesStub = sinon.stub().resolves([]);
+          const axiosPostStub = sinon.stub().resolves({
+            status: 200,
+            data: {
+              success: true,
+            } as IMultipiePublishResult,
+          });
+
+          mockedHelper.FileHelper = class {
+            public static getHomeDir = sinon.stub().returns("/home/test");
+            public configDirExists = sinon.stub().resolves(true);
+            public isConfigFileValid = sinon.stub().resolves(true);
+            public findProjectByName = findProjectByNameStub;
+            public getConfigObject = getConfigObjectStub;
+          }
+
+          mockedHelper.GitHelper = class {
+            public logChanges = logChangesStub;
+          }
+
+          mockedHelper.ProjectHelper = class {
+            public getOrAskForProjectFromGit = getOrAskForProjectFromGitStub;
+          }
+
+          const proxy: any = proxyquire("../../app", {
+            "./helper": mockedHelper,
+            "axios": {
+              post: axiosPostStub,
+            },
+          });
+
+          const mockedApp: App = new proxy.App();
+
+          await mockedApp.setup();
+
+          const mockedCommand: Command = new Command();
+
+          // Mock arguments array to enable interactive mode
+          process.argv = ["1", "2", "3"];
+
+          await mockedApp.publishAction(mockedCommand);
+
+          assert.isTrue(findProjectByNameStub.calledOnce);
+          assert.isTrue(getConfigObjectStub.calledOnce);
+          assert.isTrue(getOrAskForProjectFromGitStub.calledOnce);
+          assert.isTrue(axiosPostStub.calledOnce);
+        });
+
+        it("should publish records to Multipie endpoint [non interactive]", async function () {
+          const mockedHelper: any = Object.assign({}, emptyHelper);
+
+          const getProjectByNameStub = sinon.stub().returns({
+            meta: {
+              host: "github.com",
+              port: 443,
+            },
+            name: "mocked_project_1",
+          } as IProject);
+          const getConfigObjectStub = sinon.stub().returns({
+            created: 1234,
+            gitRepo: "ssh://git@mocked.com:1337/mocked/test.git",
+            links: [
+              {
+                host: "http://multipie.mocked.com:2990",
+                endpoint: "/v1/publish",
+                linkType: "Multipie",
+                projectName: "mocked_project_1",
+                username: "test",
+              } as IMultipieLink,
+            ],
+          } as IConfigFile);
+          const findProjectByNameStub = sinon.stub().resolves({
+            meta: {
+              host: "github.com",
+              port: 443,
+            },
+            name: "mocked_project_1",
+            records: [],
+          });
+          const logChangesStub = sinon.stub().resolves([]);
+          const axiosPostStub = sinon.stub().resolves({
+            status: 201,
+            data: {
+              success: true,
+            } as IMultipiePublishResult,
+          });
+
+          mockedHelper.FileHelper = class {
+            public static getHomeDir = sinon.stub().returns("/home/test");
+            public configDirExists = sinon.stub().resolves(true);
+            public isConfigFileValid = sinon.stub().resolves(true);
+            public findProjectByName = findProjectByNameStub;
+            public getConfigObject = getConfigObjectStub;
+          }
+
+          mockedHelper.GitHelper = class {
+            public logChanges = logChangesStub;
+          }
+
+          mockedHelper.ProjectHelper = class {
+            public getProjectByName = getProjectByNameStub;
+          }
+
+          const proxy: any = proxyquire("../../app", {
+            "./helper": mockedHelper,
+            "axios": {
+              post: axiosPostStub,
+            },
+          });
+
+          const mockedApp: App = new proxy.App();
+
+          await mockedApp.setup();
+
+          const mockedCommand: Command = new Command();
+          mockedCommand.project = "mocked_project_1";
+
+          // Mock arguments array to disable interactive mode
+          process.argv = ["1", "2", "3", "4"];
+
+          await mockedApp.publishAction(mockedCommand);
+
+          assert.isTrue(findProjectByNameStub.calledOnce);
+          assert.isTrue(getConfigObjectStub.calledOnce);
+          assert.isTrue(getProjectByNameStub.calledOnce);
+          assert.isTrue(axiosPostStub.calledOnce);
+        });
+
+
+        it("should fail to publish records to Multipie endpoint [request fails]", async function () {
+          const mockedHelper: any = Object.assign({}, emptyHelper);
+
+          const getOrAskForProjectFromGitStub = sinon.stub().resolves({
+            meta: {
+              host: "test.git.com",
+              port: 443,
+            },
+            name: "mocked_project_1",
+          } as IProject);
+          const getConfigObjectStub = sinon.stub().returns({
+            created: 1234,
+            gitRepo: "ssh://git@mocked.com:1337/mocked/test.git",
+            links: [
+              {
+                host: "http://multipie.mocked.com:2990",
+                endpoint: "/v1/publish",
+                linkType: "Multipie",
+                projectName: "mocked_project_1",
+                username: "test",
+              } as IMultipieLink,
+            ],
+          } as IConfigFile);
+          const findProjectByNameStub = sinon.stub().resolves({
+            meta: {
+              host: "github.com",
+              port: 443,
+            },
+            name: "mocked_project_1",
+            records: [],
+          });
+          const axiosPostStub = sinon.stub().throws(new Error("Mocked Error"));
+          mockedHelper.FileHelper = class {
+            public static getHomeDir = sinon.stub().returns("/home/test");
+            public configDirExists = sinon.stub().resolves(true);
+            public isConfigFileValid = sinon.stub().resolves(true);
+            public findProjectByName = findProjectByNameStub;
+            public getConfigObject = getConfigObjectStub;
+          }
+
+          mockedHelper.GitHelper = class {
+            public logChanges = sinon.stub().resolves([]);
+          }
+          mockedHelper.ProjectHelper = class {
+            public getOrAskForProjectFromGit = getOrAskForProjectFromGitStub;
+          }
+
+          const proxy: any = proxyquire("../../app", {
+            "./helper": mockedHelper,
+            "axios": {
+              post: axiosPostStub,
+            },
+          });
+
+          const mockedApp: App = new proxy.App();
+
+          const exitStub = sinon.stub(mockedApp, "exit");
+
+          await mockedApp.setup();
+
+          const mockedCommand: Command = new Command();
+
+          // Mock arguments array to enable interactive mode
+          process.argv = ["1", "2", "3"];
+
+          await mockedApp.publishAction(mockedCommand);
+
+          assert.isTrue(axiosPostStub.calledOnce);
+          assert.isTrue(exitStub.called);
+
+          exitStub.restore();
+        });
+
+        it("should fail to publish records to Multipie endpoint [unsuccessful response]", async function () {
+          const mockedHelper: any = Object.assign({}, emptyHelper);
+
+          const getOrAskForProjectFromGitStub = sinon.stub().resolves({
+            meta: {
+              host: "test.git.com",
+              port: 443,
+            },
+            name: "mocked_project_1",
+          } as IProject);
+          const getConfigObjectStub = sinon.stub().returns({
+            created: 1234,
+            gitRepo: "ssh://git@mocked.com:1337/mocked/test.git",
+            links: [
+              {
+                host: "http://multipie.mocked.com:2990",
+                endpoint: "/v1/publish",
+                linkType: "Multipie",
+                projectName: "mocked_project_1",
+                username: "test",
+              } as IMultipieLink,
+            ],
+          } as IConfigFile);
+          const findProjectByNameStub = sinon.stub().resolves({
+            meta: {
+              host: "github.com",
+              port: 443,
+            },
+            name: "mocked_project_1",
+            records: [],
+          });
+          const axiosPostStub = sinon.stub().resolves({
+            status: 500,
+            data: {
+              success: false,
+            } as IMultipiePublishResult,
+          });
+
+          mockedHelper.FileHelper = class {
+            public static getHomeDir = sinon.stub().returns("/home/test");
+            public configDirExists = sinon.stub().resolves(true);
+            public isConfigFileValid = sinon.stub().resolves(true);
+            public findProjectByName = findProjectByNameStub;
+            public getConfigObject = getConfigObjectStub;
+          }
+
+          mockedHelper.GitHelper = class {
+            public logChanges = sinon.stub().resolves([]);
+          }
+          mockedHelper.ProjectHelper = class {
+            public getOrAskForProjectFromGit = getOrAskForProjectFromGitStub;
+          }
+
+          const proxy: any = proxyquire("../../app", {
+            "./helper": mockedHelper,
+            "axios": {
+              post: axiosPostStub,
+            },
+          });
+
+          const mockedApp: App = new proxy.App();
+
+          const exitStub = sinon.stub(mockedApp, "exit");
+
+          await mockedApp.setup();
+
+          const mockedCommand: Command = new Command();
+
+          // Mock arguments array to enable interactive mode
+          process.argv = ["1", "2", "3"];
+
+          await mockedApp.publishAction(mockedCommand);
+
+          assert.isTrue(axiosPostStub.calledOnce);
+          assert.isTrue(exitStub.called);
+
+          exitStub.restore();
+        });
+
       });
     });
   });

--- a/test/unit/file.helper.test.ts
+++ b/test/unit/file.helper.test.ts
@@ -755,7 +755,7 @@ describe("FileHelper", function () {
       const updatedConfigFile: IConfigFile = await instance.addOrUpdateLink({
         linkType: "mock",
         projectName: "mocked",
-      });
+      }, "mock");
 
       expect(updatedConfigFile.links.length).to.eq(1);
 
@@ -791,7 +791,7 @@ describe("FileHelper", function () {
         linkType: "mock",
         projectName: "mocked",
         username: "mock",
-      });
+      }, "mock");
 
       expect(updatedConfigFile.links.length).to.eq(1);
 
@@ -822,7 +822,7 @@ describe("FileHelper", function () {
         },
         name: "mocked",
         records: [],
-      } as IProject);
+      } as IProject, "mock");
 
       assert.isDefined(foundLink);
 
@@ -852,14 +852,15 @@ describe("FileHelper", function () {
         },
         name: "unknown",
         records: [],
-      } as IProject);
+      } as IProject, "mock");
 
       assert.isUndefined(foundLink);
 
       assert.isTrue(getConfigObjectStub.calledOnce);
     });
 
-    it("should fail to find link by project [more links for same project name]", async function () {
+    // TODO should be re-enabled when multiple links are supported
+    it.skip("should fail to find link by project [more links for same project name]", async function () {
       const fileProxy: any = proxyquire("../../helper/file", {});
 
       const instance: FileHelper = new fileProxy.FileHelper(configDir, configFileName, timerFileName, projectsDir);
@@ -886,7 +887,7 @@ describe("FileHelper", function () {
         },
         name: "mocked",
         records: [],
-      } as IProject);
+      } as IProject, "mock");
 
       assert.isUndefined(foundLink);
 

--- a/test/unit/file.helper.test.ts
+++ b/test/unit/file.helper.test.ts
@@ -755,7 +755,7 @@ describe("FileHelper", function () {
       const updatedConfigFile: IConfigFile = await instance.addOrUpdateLink({
         linkType: "mock",
         projectName: "mocked",
-      }, "mock");
+      });
 
       expect(updatedConfigFile.links.length).to.eq(1);
 
@@ -791,7 +791,7 @@ describe("FileHelper", function () {
         linkType: "mock",
         projectName: "mocked",
         username: "mock",
-      }, "mock");
+      });
 
       expect(updatedConfigFile.links.length).to.eq(1);
 
@@ -822,7 +822,7 @@ describe("FileHelper", function () {
         },
         name: "mocked",
         records: [],
-      } as IProject, "mock");
+      } as IProject);
 
       assert.isDefined(foundLink);
 
@@ -852,7 +852,7 @@ describe("FileHelper", function () {
         },
         name: "unknown",
         records: [],
-      } as IProject, "mock");
+      } as IProject);
 
       assert.isUndefined(foundLink);
 
@@ -860,7 +860,7 @@ describe("FileHelper", function () {
     });
 
     // TODO should be re-enabled when multiple links are supported
-    it.skip("should fail to find link by project [more links for same project name]", async function () {
+    it("should fail to find link by project [more links for same project name]", async function () {
       const fileProxy: any = proxyquire("../../helper/file", {});
 
       const instance: FileHelper = new fileProxy.FileHelper(configDir, configFileName, timerFileName, projectsDir);
@@ -887,7 +887,7 @@ describe("FileHelper", function () {
         },
         name: "mocked",
         records: [],
-      } as IProject, "mock");
+      } as IProject);
 
       assert.isUndefined(foundLink);
 

--- a/test/unit/question.helper.test.ts
+++ b/test/unit/question.helper.test.ts
@@ -4,6 +4,7 @@ import sinon from "sinon";
 import { QuestionHelper } from "../../helper";
 import { IJiraLink, IProject, IRecord } from "../../interfaces";
 import { RECORD_TYPES } from "../../types";
+import { IMultipieLink } from '../../interfaces/index';
 
 describe("QuestionHelper", function () {
   describe("Static", function () {
@@ -131,133 +132,194 @@ describe("QuestionHelper", function () {
       expect(choice).to.eq("ssh://git@github.com/company/project.git");
     });
 
-    it("should ask for jira link", async function () {
-      const proxy: any = proxyquire("../../helper/question", {
-        inquirer: {
-          prompt: sinon.stub().resolves({
-            host: "http://mocked.com",
-            key: "MOCKED",
-            password: "mocked",
-            username: "mocked",
-          }),
-        },
+    describe("Jira", function () {
+      it("should ask for jira link", async function () {
+        const proxy: any = proxyquire("../../helper/question", {
+          inquirer: {
+            prompt: sinon.stub().resolves({
+              host: "http://mocked.com",
+              key: "MOCKED",
+              password: "mocked",
+              username: "mocked",
+            }),
+          },
+        });
+
+        const choice: IJiraLink = await proxy.QuestionHelper.askJiraLink({
+          meta: {
+            host: "mocked.com",
+            port: 443,
+          },
+          name: "mocked_project_1",
+        } as IProject);
+
+        expect(choice.host).to.eq("http://mocked.com");
+        expect(choice.endpoint).to.eq("/rest/gittt/latest/");
+        expect(choice.key).to.eq("MOCKED");
+        expect(choice.username).to.eq("mocked");
+        expect(choice.hash).to.eq("bW9ja2VkOm1vY2tlZA==");
+        expect(choice.linkType).to.eq("Jira");
+        expect(choice.projectName).to.eq("mocked_project_1");
       });
 
-      const choice: IJiraLink = await proxy.QuestionHelper.askJiraLink({
-        meta: {
-          host: "mocked.com",
-          port: 443,
-        },
-        name: "mocked_project_1",
-      } as IProject);
+      it("should ask for jira link with issue", async function () {
+        const proxy: any = proxyquire("../../helper/question", {
+          inquirer: {
+            prompt: sinon.stub().resolves({
+              host: "http://mocked.com",
+              key: "MOCKED",
+              issue: "EPIC-1",
+              password: "mocked",
+              username: "mocked",
+            }),
+          },
+        });
 
-      expect(choice.host).to.eq("http://mocked.com");
-      expect(choice.endpoint).to.eq("/rest/gittt/latest/");
-      expect(choice.key).to.eq("MOCKED");
-      expect(choice.username).to.eq("mocked");
-      expect(choice.hash).to.eq("bW9ja2VkOm1vY2tlZA==");
-      expect(choice.linkType).to.eq("Jira");
-      expect(choice.projectName).to.eq("mocked_project_1");
-    });
+        const choice: IJiraLink = await proxy.QuestionHelper.askJiraLink({
+          meta: {
+            host: "mocked.com",
+            port: 443,
+          },
+          name: "mocked_project_1",
+        } as IProject);
 
-    it("should ask for jira link with issue", async function () {
-      const proxy: any = proxyquire("../../helper/question", {
-        inquirer: {
-          prompt: sinon.stub().resolves({
+        expect(choice.host).to.eq("http://mocked.com");
+        expect(choice.endpoint).to.eq("/rest/gittt/latest/");
+        expect(choice.key).to.eq("MOCKED");
+        expect(choice.issue).to.eq("EPIC-1");
+        expect(choice.username).to.eq("mocked");
+        expect(choice.hash).to.eq("bW9ja2VkOm1vY2tlZA==");
+        expect(choice.linkType).to.eq("Jira");
+        expect(choice.projectName).to.eq("mocked_project_1");
+      });
+
+      it("should ask for jira link with previous data", async function () {
+        const proxy: any = proxyquire("../../helper/question", {
+          inquirer: {
+            prompt: sinon.stub().resolves({
+              host: "http://mocked.com",
+              key: "MOCKED",
+              issue: "EPIC-1",
+              username: "mocked",
+            }),
+          },
+        });
+
+        const choice: IJiraLink = await proxy.QuestionHelper.askJiraLink({
+          meta: {
+            host: "mocked.com",
+            port: 443,
+          },
+          name: "mocked_project_1",
+        } as IProject
+          , {
+            endpoint: "/rest/gittt/latest/",
+            hash: "bW9ja2VkOm1vY2tlZA==",
             host: "http://mocked.com",
-            key: "MOCKED",
             issue: "EPIC-1",
-            password: "mocked",
-            username: "mocked",
-          }),
-        },
+            key: "MOCKED",
+            linkType: "Jira",
+            projectName: "mocked_project_1",
+            username: "mocked"
+          } as IJiraLink);
+
+        expect(choice.host).to.eq("http://mocked.com");
+        expect(choice.endpoint).to.eq("/rest/gittt/latest/");
+        expect(choice.key).to.eq("MOCKED");
+        expect(choice.issue).to.eq("EPIC-1");
+        expect(choice.username).to.eq("mocked");
+        expect(choice.hash).to.eq("bW9ja2VkOm1vY2tlZA==");
+        expect(choice.linkType).to.eq("Jira");
+        expect(choice.projectName).to.eq("mocked_project_1");
       });
 
-      const choice: IJiraLink = await proxy.QuestionHelper.askJiraLink({
-        meta: {
-          host: "mocked.com",
-          port: 443,
-        },
-        name: "mocked_project_1",
-      } as IProject);
+      it("should ask for jira link [with endpoint version]", async function () {
+        const proxy: any = proxyquire("../../helper/question", {
+          inquirer: {
+            prompt: sinon.stub().resolves({
+              host: "http://mocked.com",
+              key: "MOCKED",
+              password: "mocked",
+              username: "mocked",
+            }),
+          },
+        });
 
-      expect(choice.host).to.eq("http://mocked.com");
-      expect(choice.endpoint).to.eq("/rest/gittt/latest/");
-      expect(choice.key).to.eq("MOCKED");
-      expect(choice.issue).to.eq("EPIC-1");
-      expect(choice.username).to.eq("mocked");
-      expect(choice.hash).to.eq("bW9ja2VkOm1vY2tlZA==");
-      expect(choice.linkType).to.eq("Jira");
-      expect(choice.projectName).to.eq("mocked_project_1");
+        const choice: IJiraLink = await proxy.QuestionHelper.askJiraLink({
+          meta: {
+            host: "mocked.com",
+            port: 443,
+          },
+          name: "mocked_project_1",
+        } as IProject, undefined, "2.0.0");
+
+        expect(choice.host).to.eq("http://mocked.com");
+        expect(choice.endpoint).to.eq("/rest/gittt/2.0.0/");
+        expect(choice.key).to.eq("MOCKED");
+        expect(choice.username).to.eq("mocked");
+        expect(choice.hash).to.eq("bW9ja2VkOm1vY2tlZA==");
+        expect(choice.linkType).to.eq("Jira");
+        expect(choice.projectName).to.eq("mocked_project_1");
+      });
     });
 
-    it("should ask for jira link with previous data", async function () {
-      const proxy: any = proxyquire("../../helper/question", {
-        inquirer: {
-          prompt: sinon.stub().resolves({
-            host: "http://mocked.com",
-            key: "MOCKED",
-            issue: "EPIC-1",
-            username: "mocked",
-          }),
-        },
+    describe("Multipie", function () {
+      it("should ask for multipie link", async function () {
+        const proxy: any = proxyquire("../../helper/question", {
+          inquirer: {
+            prompt: sinon.stub().resolves({
+              host: "http://mocked.com",
+              username: "mocked",
+            }),
+          },
+        });
+
+        const choice: IMultipieLink = await proxy.QuestionHelper.askMultipieLink({
+          meta: {
+            host: "mocked.com",
+            port: 443,
+          },
+          name: "mocked_project_1",
+        } as IProject);
+
+        expect(choice.host).to.eq("http://mocked.com");
+        expect(choice.endpoint).to.eq("/v1/publish");
+        expect(choice.username).to.eq("mocked");
+        expect(choice.linkType).to.eq("Multipie");
+        expect(choice.projectName).to.eq("mocked_project_1");
       });
 
-      const choice: IJiraLink = await proxy.QuestionHelper.askJiraLink({
-        meta: {
-          host: "mocked.com",
-          port: 443,
-        },
-        name: "mocked_project_1",
-      } as IProject
-        , {
-          endpoint: "/rest/gittt/latest/",
-          hash: "bW9ja2VkOm1vY2tlZA==",
-          host: "http://mocked.com",
-          issue: "EPIC-1",
-          key: "MOCKED",
-          linkType: "Jira",
-          projectName: "mocked_project_1",
-          username: "mocked"
-        } as IJiraLink);
+      it("should ask for multipie link with previous data", async function () {
+        const proxy: any = proxyquire("../../helper/question", {
+          inquirer: {
+            prompt: sinon.stub().resolves({
+              host: "http://mocked.com",
+              username: "mocked",
+            }),
+          },
+        });
 
-      expect(choice.host).to.eq("http://mocked.com");
-      expect(choice.endpoint).to.eq("/rest/gittt/latest/");
-      expect(choice.key).to.eq("MOCKED");
-      expect(choice.issue).to.eq("EPIC-1");
-      expect(choice.username).to.eq("mocked");
-      expect(choice.hash).to.eq("bW9ja2VkOm1vY2tlZA==");
-      expect(choice.linkType).to.eq("Jira");
-      expect(choice.projectName).to.eq("mocked_project_1");
-    });
-
-    it("should ask for jira link [with endpoint version]", async function () {
-      const proxy: any = proxyquire("../../helper/question", {
-        inquirer: {
-          prompt: sinon.stub().resolves({
+        const choice: IMultipieLink = await proxy.QuestionHelper.askMultipieLink({
+          meta: {
+            host: "mocked.com",
+            port: 443,
+          },
+          name: "mocked_project_1",
+        } as IProject
+          , {
+            endpoint: "/v1/publish",
             host: "http://mocked.com",
-            key: "MOCKED",
-            password: "mocked",
-            username: "mocked",
-          }),
-        },
+            linkType: "Multipie",
+            projectName: "mocked_project_1",
+            username: "mocked"
+          } as IMultipieLink);
+
+        expect(choice.host).to.eq("http://mocked.com");
+        expect(choice.endpoint).to.eq("/v1/publish");
+        expect(choice.username).to.eq("mocked");
+        expect(choice.linkType).to.eq("Multipie");
+        expect(choice.projectName).to.eq("mocked_project_1");
       });
-
-      const choice: IJiraLink = await proxy.QuestionHelper.askJiraLink({
-        meta: {
-          host: "mocked.com",
-          port: 443,
-        },
-        name: "mocked_project_1",
-      } as IProject, undefined, "2.0.0");
-
-      expect(choice.host).to.eq("http://mocked.com");
-      expect(choice.endpoint).to.eq("/rest/gittt/2.0.0/");
-      expect(choice.key).to.eq("MOCKED");
-      expect(choice.username).to.eq("mocked");
-      expect(choice.hash).to.eq("bW9ja2VkOm1vY2tlZA==");
-      expect(choice.linkType).to.eq("Jira");
-      expect(choice.projectName).to.eq("mocked_project_1");
     });
   });
 


### PR DESCRIPTION
This should be considered a "alpha" implementation, downsides:
- No multiple links for a single project (gittt link will override any other links)
- Some functions (e.g. info) are hardcoded to link type "jira" to avoid implementing multiple link functions