### PR TITLE
First element of csv file is in quotes

### DIFF
--- a/helper/import.ts
+++ b/helper/import.ts
@@ -14,7 +14,7 @@ export class ImportHelper {
       Papa.parse(fd, {
         header: true,
         delimiter: ',',
-        newline: '\n',
+        transformHeader: h => h.trim(),
         complete: (parsed) => {
 
           if (parsed.errors.length > 0) {


### PR DESCRIPTION
- Fixed by trim()
- Moved to automatic guessing of newline